### PR TITLE
OWXP-134 Remove unnecessary side-navigation.js reference

### DIFF
--- a/modules/linked-pages-portlet-project/src/main/resources/META-INF/resources/icon.jsp
+++ b/modules/linked-pages-portlet-project/src/main/resources/META-INF/resources/icon.jsp
@@ -24,8 +24,6 @@ PortletURL linkedPagesPanelURL = PortletURLFactoryUtil.create(request, LinkedPag
 linkedPagesPanelURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 %>
 
-<script src="side-navigation.js"></script>
-
 <li class="control-menu-nav-item">
 	<a class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler"
 		data-qa-id="Linked Pages" data-content="body" data-title="Linked Pages"


### PR DESCRIPTION
Hi Tomcsi,

Dani found a issue with commenting on a WikiPage which was caused by a side-navigation.js reference that wasn't cleared out yet. On Grow clone the updated version is deployed.
Could you please add this to the dev branch too?

Thanks,
Laci