### PR TITLE
GROW-599 Activities portlet on profile pages - pagination breaks the selector

### DIFF
--- a/modules/social-activity-customizer/social-activity-customizer-core-jsp/src/main/resources/META-INF/jsps/html/taglib/ui/social_activities/page.jsp
+++ b/modules/social-activity-customizer/social-activity-customizer-core-jsp/src/main/resources/META-INF/jsps/html/taglib/ui/social_activities/page.jsp
@@ -83,7 +83,11 @@
 		String headerName = "x's-activities";
 		%>
 
-		<liferay-ui:search-container delta="10" emptyResultsMessage="there-are-no-recent-activities" total="<%= feedEntries.size() %>">
+		<liferay-portlet:renderURL varImpl="iteratorURL">
+			<liferay-portlet:param name="activityType" value="<%= activityType %>" />
+		</liferay-portlet:renderURL>
+
+		<liferay-ui:search-container delta="10" emptyResultsMessage="there-are-no-recent-activities" total="<%= feedEntries.size() %>" iteratorURL="<%= iteratorURL %>">
 			<liferay-ui:search-container-results results="<%= ListUtil.subList(feedEntries, searchContainer.getStart(), searchContainer.getEnd()) %>" />
 
 			<liferay-ui:search-container-row className="FeedEntryHolder" keyProperty="feedEntryText" modelVar="enrty">

--- a/modules/social-activity-customizer/social-activity-customizer-core-jsp/src/main/resources/META-INF/jsps/html/taglib/ui/social_activities/page.jsp
+++ b/modules/social-activity-customizer/social-activity-customizer-core-jsp/src/main/resources/META-INF/jsps/html/taglib/ui/social_activities/page.jsp
@@ -16,6 +16,14 @@
 
 <%@ include file="/html/taglib/ui/social_activities/init.jsp" %>
 
+<%
+Integer delta = ParamUtil.getInteger(request, "delta");
+
+if (delta == null) {
+	delta = 10;
+}
+%>
+
 <div class="taglib-social-activities">
 	<c:if test="<%= feedEnabled && !activityDescriptors.isEmpty() %>">
 		<div class="clearfix">
@@ -87,7 +95,7 @@
 			<liferay-portlet:param name="activityType" value="<%= activityType %>" />
 		</liferay-portlet:renderURL>
 
-		<liferay-ui:search-container delta="10" emptyResultsMessage="there-are-no-recent-activities" total="<%= feedEntries.size() %>" iteratorURL="<%= iteratorURL %>">
+		<liferay-ui:search-container delta="<%= delta %>" emptyResultsMessage="there-are-no-recent-activities" total="<%= feedEntries.size() %>" iteratorURL="<%= iteratorURL %>">
 			<liferay-ui:search-container-results results="<%= ListUtil.subList(feedEntries, searchContainer.getStart(), searchContainer.getEnd()) %>" />
 
 			<liferay-ui:search-container-row className="FeedEntryHolder" keyProperty="feedEntryText" modelVar="enrty">
@@ -201,8 +209,9 @@ private class FeedEntryHolder {
 	window.filterByActivityType = function() {
 		var uri = '<portlet:renderURL />';
 
-		var location = Liferay.Util.addParams('<portlet:namespace />activityType=' + A.one('#<portlet:namespace />user-activity-selector').get('value'), uri);
+		uri = Liferay.Util.addParams('<portlet:namespace />activityType=' + A.one('#<portlet:namespace />user-activity-selector').get('value'), uri);
+		uri = Liferay.Util.addParams('<portlet:namespace />delta=<%= delta %>', uri);
 
-		window.location.href = location;
+		window.location.href = uri;
 	};
 </aui:script>

--- a/modules/social-activity-customizer/social-activity-customizer-core-jsp/src/main/resources/META-INF/jsps/html/taglib/ui/social_activities/page.jsp
+++ b/modules/social-activity-customizer/social-activity-customizer-core-jsp/src/main/resources/META-INF/jsps/html/taglib/ui/social_activities/page.jsp
@@ -95,7 +95,7 @@ if (delta == null) {
 			<liferay-portlet:param name="activityType" value="<%= activityType %>" />
 		</liferay-portlet:renderURL>
 
-		<liferay-ui:search-container delta="<%= delta %>" emptyResultsMessage="there-are-no-recent-activities" total="<%= feedEntries.size() %>" iteratorURL="<%= iteratorURL %>">
+		<liferay-ui:search-container delta="<%= delta %>" emptyResultsMessage="there-are-no-recent-activities" iteratorURL="<%= iteratorURL %>" total="<%= feedEntries.size() %>">
 			<liferay-ui:search-container-results results="<%= ListUtil.subList(feedEntries, searchContainer.getStart(), searchContainer.getEnd()) %>" />
 
 			<liferay-ui:search-container-row className="FeedEntryHolder" keyProperty="feedEntryText" modelVar="enrty">


### PR DESCRIPTION
[GROW-599](https://issues.liferay.com/browse/GROW-599)

Hi Tomcsi,

This PR intends to solve the following issues:
* activityType is not kept when navigating among search result pages
* paging delta is not kept when switching activityType

Please let me know if I can help you.

Thanks,
Pisti