### PR TITLE
GROW-629 Replace NBSP characters

### DIFF
--- a/modules/recommend-engine/recommend-engine-service/src/main/java/com/liferay/recommend/service/impl/RecommendEntityLocalServiceImpl.java
+++ b/modules/recommend-engine/recommend-engine-service/src/main/java/com/liferay/recommend/service/impl/RecommendEntityLocalServiceImpl.java
@@ -232,7 +232,7 @@ public class RecommendEntityLocalServiceImpl
 	private static final char[] _REPLACE = {
 		'\u00e1', '\u00e9', '\u00ed', '\u00fa', '\u00fc', '\u0171', '\u00f3',
 		'\u00f6', '\u0151', '&', '\'', '@', ']', ')', ':', ',', '$', '=', '!',
-		'[', '(', '#', '?', ';', '/', '*', '+', ' '
+		'[', '(', '#', '?', ';', '/', '*', '+', ' ', '\u00a0'
 	};
 
 	private static final String[] _REPLACE_WITH = {
@@ -240,7 +240,7 @@ public class RecommendEntityLocalServiceImpl
 			"<APOSTROPHE>","<AT>", "<CLOSE_BRACKET>", "<CLOSE_PARENTHESIS>",
 			"<COLON>", "<COMMA>","<DOLLAR>", "<EQUAL>", "<EXCLAMATION>",
 			"<OPEN_BRACKET>", "<OPEN_PARENTHESIS>", "<POUND>", "<QUESTION>",
-			"<SEMICOLON>","<SLASH>", "<STAR>","<PLUS>","+"
+			"<SEMICOLON>","<SLASH>", "<STAR>","<PLUS>","+","%c2%a0"
 		};
 
 	private static final String[] _ROOT_TITLES =

--- a/modules/wiki-quicklink-web/src/main/java/com/liferay/grow/wiki/quicklink/portlet/WikiQuicklinkPortlet.java
+++ b/modules/wiki-quicklink-web/src/main/java/com/liferay/grow/wiki/quicklink/portlet/WikiQuicklinkPortlet.java
@@ -162,7 +162,7 @@ public class WikiQuicklinkPortlet extends MVCPortlet {
 
 	private static final char[] REPLACE = {
 		'á', 'é', 'í', 'ú', 'ü', '\u0171', 'ó', 'ö', '\u0151', '&', '\'', '@', ']', ')',
-		':', ',', '$', '=', '!', '[', '(', '#', '?', ';', '/', '*', '+', ' '
+		':', ',', '$', '=', '!', '[', '(', '#', '?', ';', '/', '*', '+', ' ', '\u00a0'
 	};
 
 	private static final String[] REPLACE_WITH = {
@@ -170,7 +170,7 @@ public class WikiQuicklinkPortlet extends MVCPortlet {
 		"<APOSTROPHE>","<AT>", "<CLOSE_BRACKET>", "<CLOSE_PARENTHESIS>",
 		"<COLON>", "<COMMA>","<DOLLAR>", "<EQUAL>", "<EXCLAMATION>",
 		"<OPEN_BRACKET>", "<OPEN_PARENTHESIS>", "<POUND>", "<QUESTION>",
-		"<SEMICOLON>","<SLASH>", "<STAR>","<PLUS>","+"
+		"<SEMICOLON>","<SLASH>", "<STAR>","<PLUS>","+","%c2%a0"
 	};
 
 	private WikiPageLocalService _wikiPageLocalService;


### PR DESCRIPTION
GROW-629 Replace NBSP characters (\u00a0) with "%c2%a0" codes when generating URLs from wiki page titles